### PR TITLE
TASK: Refactor authentication logic, remove unnecessary config

### DIFF
--- a/Classes/Security/Authentication/Provider/LdapProvider.php
+++ b/Classes/Security/Authentication/Provider/LdapProvider.php
@@ -128,7 +128,7 @@ class LdapProvider extends PersistedUsernamePasswordProvider
      * @param array $credentials array containing username and password
      * @return Account
      */
-    protected function createAccountForCredentials()
+    protected function createAccountForCredentials(array $credentials)
     {
         $account = new Account();
         $account->setAccountIdentifier($credentials['username']);

--- a/Classes/Security/Authentication/Provider/LdapProvider.php
+++ b/Classes/Security/Authentication/Provider/LdapProvider.php
@@ -11,11 +11,8 @@ namespace Neos\Ldap\Security\Authentication\Provider;
  * source code.
  */
 
-use Neos\Eel\CompilingEvaluator;
-use Neos\Eel\Context;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Log\SecurityLoggerInterface;
-use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Security\Account;
 use Neos\Flow\Security\Authentication\Provider\PersistedUsernamePasswordProvider;
 use Neos\Flow\Security\Authentication\Token\UsernamePassword;
@@ -31,35 +28,12 @@ use Neos\Ldap\Service\DirectoryService;
  */
 class LdapProvider extends PersistedUsernamePasswordProvider
 {
-    /**
-     * @Flow\InjectConfiguration(path="defaultContext", package="Neos.Ldap")
-     * @var array
-     */
-    protected $defaultContext;
 
     /**
      * @Flow\InjectConfiguration(path="roles", package="Neos.Ldap")
      * @var array
      */
     protected $rolesConfiguration;
-
-    /**
-     * @Flow\InjectConfiguration(path="party", package="Neos.Ldap")
-     * @var array
-     */
-    protected $partyConfiguration;
-
-    /**
-     * @Flow\Inject
-     * @var CompilingEvaluator
-     */
-    protected $eelEvaluator;
-
-    /**
-     * @Flow\Inject
-     * @var ObjectManagerInterface
-     */
-    protected $objectManager;
 
     /**
      * @Flow\Inject
@@ -89,7 +63,7 @@ class LdapProvider extends PersistedUsernamePasswordProvider
     }
 
     /**
-     * Authenticate the current token. If it's not possible to connect to the Ldap server the provider
+     * Authenticate the current token. If it's not possible to connect to the LDAP server the provider
      * tries to authenticate against cached credentials in the database that were
      * cached on the last successful login for the user to authenticate.
      *
@@ -99,78 +73,67 @@ class LdapProvider extends PersistedUsernamePasswordProvider
      */
     public function authenticate(TokenInterface $authenticationToken)
     {
+        // we can only authenticate users by password
         if (!($authenticationToken instanceof UsernamePassword)) {
             throw new UnsupportedAuthenticationTokenException('This provider cannot authenticate the given token.', 1217339840);
         }
-
-        $account = null;
+        
+        // do not accept empty or malformed credentials
         $credentials = $authenticationToken->getCredentials();
-
-        if (is_array($credentials) && isset($credentials['username'])) {
-            try {
-                $ldapUser = $this->directoryService->authenticate($credentials['username'], $credentials['password']);
-                if ($ldapUser) {
-                    $account = $this->accountRepository->findActiveByAccountIdentifierAndAuthenticationProviderName($credentials['username'], $this->name);
-                    $newlyCreatedAccount = false;
-                    if ($account === null) {
-                        $account = new Account();
-                        $account->setAccountIdentifier($credentials['username']);
-                        $account->setAuthenticationProviderName($this->name);
-
-                        $this->createParty($account, $ldapUser);
-
-                        $this->accountRepository->add($account);
-                        $newlyCreatedAccount = true;
-                    }
-
-                    if ($account instanceof Account) {
-                        $authenticationToken->setAuthenticationStatus(TokenInterface::AUTHENTICATION_SUCCESSFUL);
-                        $authenticationToken->setAccount($account);
-
-                        $this->setRoles($account, $ldapUser);
-                        $this->emitRolesSet($account, $ldapUser);
-                        if ($newlyCreatedAccount === false) {
-                            $this->updateParty($account, $ldapUser);
-                        }
-                        $this->emitAccountAuthenticated($account, $ldapUser);
-                        $this->accountRepository->update($account);
-
-                    } elseif ($authenticationToken->getAuthenticationStatus() !== TokenInterface::AUTHENTICATION_SUCCESSFUL) {
-                        $authenticationToken->setAuthenticationStatus(TokenInterface::NO_CREDENTIALS_GIVEN);
-                    }
-                } else {
-                    $authenticationToken->setAuthenticationStatus(TokenInterface::WRONG_CREDENTIALS);
-                }
-            } catch (\Exception $exception) {
-                $this->logger->log('Authentication failed: ' . $exception->getMessage(), LOG_ALERT);
-            }
-        } else {
-            $authenticationToken->setAuthenticationStatus(TokenInterface::NO_CREDENTIALS_GIVEN);
+        if (!is_array($credentials) || !isset($credentials['username'])) {
+            return $authenticationToken->setAuthenticationStatus(TokenInterface::NO_CREDENTIALS_GIVEN);
         }
+
+        // retrieve user data from the remote directory server
+        try {
+            $ldapUser = null;
+            $ldapUser = $this->directoryService->authenticate($credentials['username'], $credentials['password']);
+        } catch (\Exception $exception) {
+            $this->logger->log('Authentication failed: ' . $exception->getMessage(), LOG_ALERT);
+        }
+
+        // fail authentication if the directory server does not know any user with the given credentials
+        if ($ldapUser === null) {
+            return $authenticationToken->setAuthenticationStatus(TokenInterface::WRONG_CREDENTIALS);
+        }
+
+        // retrieve or create account for the credentials
+        $account = $this->accountRepository->findActiveByAccountIdentifierAndAuthenticationProviderName($credentials['username'], $this->name);
+        if ($account === null) {
+            $account = $this->createAccountForCredentials($credentials);
+            $this->emitAccountCreated($account, $ldapUser);
+        }
+
+        // fail authentication if no account was found and none was created
+        if ($account === null) {
+            return $authenticationToken->setAuthenticationStatus(TokenInterface::WRONG_CREDENTIALS);
+        }
+
+        // map user and group dns to security roles
+        $this->setRoles($account, $ldapUser);
+        $this->emitRolesSet($account, $ldapUser);
+
+        // mark authentication successful
+        $authenticationToken->setAuthenticationStatus(TokenInterface::AUTHENTICATION_SUCCESSFUL);
+        $authenticationToken->setAccount($account);
+        $this->emitAccountAuthenticated($account, $ldapUser);
     }
 
     /**
-     * Create a new party for a user's first login
-     * Extend this Provider class and implement this method to create a party
+     * Create a new account for the given credentials. Return null if you
+     * do not want to create a new account, that is, only authenticate
+     * existing accounts from the database and fail on new logins.
      *
-     * @param Account $account The freshly created account that should be used for this party
-     * @param array $ldapSearchResult The first result returned by ldap_search
-     * @return void
+     * @param array $credentials array containing username and password
+     * @return Account
      */
-    protected function createParty(Account $account, array $ldapSearchResult)
+    protected function createAccountForCredentials()
     {
-    }
-
-    /**
-     * Update the party for a user on subsequent logins
-     * Extend this Provider class and implement this method to update the party
-     *
-     * @param Account $account The account with the party
-     * @param array $ldapSearchResult
-     * @return void
-     */
-    protected function updateParty(Account $account, array $ldapSearchResult)
-    {
+        $account = new Account();
+        $account->setAccountIdentifier($credentials['username']);
+        $account->setAuthenticationProviderName($this->name);
+        $this->accountRepository->add($account);
+        return $account;
     }
 
     /**
@@ -183,51 +146,38 @@ class LdapProvider extends PersistedUsernamePasswordProvider
      */
     protected function setRoles(Account $account, array $ldapSearchResult)
     {
-        if (is_array($this->rolesConfiguration)) {
-            $contextVariables = array(
-                'ldapUser' => $ldapSearchResult,
-            );
-            if (isset($this->defaultContext) && is_array($this->defaultContext)) {
-                foreach ($this->defaultContext as $contextVariable => $objectName) {
-                    $object = $this->objectManager->get($objectName);
-                    $contextVariables[$contextVariable] = $object;
-                }
-            }
-
-            foreach ($this->rolesConfiguration['default'] as $roleIdentifier) {
-                $role = $this->policyService->getRole($roleIdentifier);
-                $account->addRole($role);
-            }
-
-            $eelContext = new Context($contextVariables);
-            if (isset($this->partyConfiguration['dn'])) {
-                $dn = $this->eelEvaluator->evaluate($this->partyConfiguration['dn'], $eelContext);
-                foreach ($this->rolesConfiguration['userMapping'] as $roleIdentifier => $userDns) {
-                    if (in_array($dn, $userDns)) {
-                        $role = $this->policyService->getRole($roleIdentifier);
-                        $account->addRole($role);
-                    }
-                }
-            } elseif (!empty($this->rolesConfiguration['userMapping'])) {
-                $this->logger->log('User mapping found but no party mapping for dn set', LOG_ALERT);
-            }
-
-            if (isset($this->partyConfiguration['username'])) {
-                $username = $this->eelEvaluator->evaluate($this->partyConfiguration['username'], $eelContext);
-                $groupMembership = $this->directoryService->getGroupMembership($username);
-                foreach ($this->rolesConfiguration['groupMapping'] as $roleIdentifier => $remoteRoleIdentifiers) {
-                    foreach ($remoteRoleIdentifiers as $remoteRoleIdentifier) {
-                        $role = $this->policyService->getRole($roleIdentifier);
-
-                        if (isset($groupMembership[$remoteRoleIdentifier])) {
-                            $account->addRole($role);
-                        }
-                    }
-                }
-            } elseif (!empty($this->rolesConfiguration['groupMapping'])) {
-                $this->logger->log('Group mapping found but no party mapping for username set', LOG_ALERT);
+        // map all default roles to the account
+        foreach ($this->rolesConfiguration['default'] as $roleIdentifier) {
+            $account->addRole($this->policyService->getRole($roleIdentifier));
+        }
+        
+        // map users dns to roles
+        foreach ($this->rolesConfiguration['userMapping'] as $roleIdentifier => $userDns) {
+            if (in_array($ldapSearchResult['dn'], $userDns)) {
+                $account->addRole($this->policyService->getRole($roleIdentifier));
             }
         }
+        
+        // map group dns to roles
+        $memberOf = $this->directoryService->getMemberOf($ldapSearchResult['dn']);
+        foreach ($this->rolesConfiguration['groupMapping'] as $roleIdentifier => $groupDns) {
+            if (!empty(array_intersect($memberOf, $groupDns))) {
+                $account->addRole($this->policyService->getRole($roleIdentifier));
+            }
+        }
+
+        // persist role changes
+        $this->accountRepository->update($account);
+    }
+
+    /**
+     * @param Account $account
+     * @param array $ldapSearchResult
+     * @return void
+     * @Flow\Signal
+     */
+    public function emitAccountCreated(Account $account, array $ldapSearchResult)
+    {
     }
 
     /**

--- a/Classes/Security/Authentication/Provider/LdapProvider.php
+++ b/Classes/Security/Authentication/Provider/LdapProvider.php
@@ -77,7 +77,7 @@ class LdapProvider extends PersistedUsernamePasswordProvider
         if (!($authenticationToken instanceof UsernamePassword)) {
             throw new UnsupportedAuthenticationTokenException('This provider cannot authenticate the given token.', 1217339840);
         }
-        
+
         // do not accept empty or malformed credentials
         $credentials = $authenticationToken->getCredentials();
         if (!is_array($credentials) || !isset($credentials['username'])) {
@@ -105,8 +105,8 @@ class LdapProvider extends PersistedUsernamePasswordProvider
             // fail authentication if no account was found and none was created
             if ($account === null) {
                 return $authenticationToken->setAuthenticationStatus(TokenInterface::WRONG_CREDENTIALS);
-            } 
-            
+            }
+
             $this->emitAccountCreated($account, $ldapUser);
         }
 
@@ -151,14 +151,14 @@ class LdapProvider extends PersistedUsernamePasswordProvider
         foreach ($this->rolesConfiguration['default'] as $roleIdentifier) {
             $account->addRole($this->policyService->getRole($roleIdentifier));
         }
-        
+
         // map users dns to roles
         foreach ($this->rolesConfiguration['userMapping'] as $roleIdentifier => $userDns) {
             if (in_array($ldapSearchResult['dn'], $userDns)) {
                 $account->addRole($this->policyService->getRole($roleIdentifier));
             }
         }
-        
+
         // map group dns to roles
         $memberOf = $this->directoryService->getMemberOf($ldapSearchResult['dn']);
         foreach ($this->rolesConfiguration['groupMapping'] as $roleIdentifier => $groupDns) {

--- a/Classes/Security/Authentication/Provider/LdapProvider.php
+++ b/Classes/Security/Authentication/Provider/LdapProvider.php
@@ -101,12 +101,13 @@ class LdapProvider extends PersistedUsernamePasswordProvider
         $account = $this->accountRepository->findActiveByAccountIdentifierAndAuthenticationProviderName($credentials['username'], $this->name);
         if ($account === null) {
             $account = $this->createAccountForCredentials($credentials);
-            $this->emitAccountCreated($account, $ldapUser);
-        }
 
-        // fail authentication if no account was found and none was created
-        if ($account === null) {
-            return $authenticationToken->setAuthenticationStatus(TokenInterface::WRONG_CREDENTIALS);
+            // fail authentication if no account was found and none was created
+            if ($account === null) {
+                return $authenticationToken->setAuthenticationStatus(TokenInterface::WRONG_CREDENTIALS);
+            } 
+            
+            $this->emitAccountCreated($account, $ldapUser);
         }
 
         // map user and group dns to security roles

--- a/Classes/Service/DirectoryService.php
+++ b/Classes/Service/DirectoryService.php
@@ -171,7 +171,7 @@ class DirectoryService
      * @return array
      * @throws Exception
      */
-    public function getGroupMembership($username)
+    public function getMemberOf($username)
     {
         $groups = array();
         $groupFilterOptions = Arrays::arrayMergeRecursiveOverrule(

--- a/Classes/Service/DirectoryService.php
+++ b/Classes/Service/DirectoryService.php
@@ -74,13 +74,14 @@ class DirectoryService
             return;
         }
         
-        $bindProviderClassName = $this->options['bindProvider'];
-        if (!class_exists($bindProviderClassName)) {
+        $defaultClass = 'Neos\Ldap\Service\BindProvider\LdapBind';
+        $bindProviderClass = isset($this->options['bindProvider']) ? $this->options['bindProvider'] : $defaultClass;
+        if (!class_exists($bindProviderClass)) {
             throw new Exception('Bind provider for the service "' . $this->name . '" could not be resolved.', 1327756744);
         }
 
         $connection = ldap_connect($this->options['host'], $this->options['port']);
-        $this->bindProvider = new $bindProviderClassName($connection, $this->options);
+        $this->bindProvider = new $bindProviderClass($connection, $this->options);
         $this->setLdapOptions();
     }
 

--- a/Classes/Service/DirectoryService.php
+++ b/Classes/Service/DirectoryService.php
@@ -49,7 +49,7 @@ class DirectoryService
         $this->name = $name;
         $this->options = $options;
     }
-    
+
     /**
      * @return resource
      */
@@ -75,7 +75,7 @@ class DirectoryService
         }
 
         $defaultClass = 'Neos\Ldap\Service\BindProvider\LdapBind';
-        $bindProviderClass = isset($this->options['bindProvider']) ? $this->options['bindProvider'] : $defaultClass;
+        $bindProviderClass = isset($this->options['bind']['provider']) ? $this->options['bind']['provider'] : $defaultClass;
         if (!class_exists($bindProviderClass)) {
             throw new Exception("Bind provider '$bindProviderClass' for the service '$this->name' could not be resolved.", 1327756744);
         }
@@ -117,7 +117,7 @@ class DirectoryService
     public function authenticate($username, $password)
     {
         $this->bind($username, $password);
-        
+
         $searchResult = @ldap_search(
             $this->bindProvider->getLinkIdentifier(),
             $this->options['baseDn'],

--- a/Classes/Service/DirectoryService.php
+++ b/Classes/Service/DirectoryService.php
@@ -80,7 +80,7 @@ class DirectoryService
     }
 
     /**
-     * Set the Ldap options configured in the settings
+     * Set the Ldap options configured in the settings.
      *
      * Loops over the ldapOptions array, and finds the corresponding Ldap option by prefixing
      * LDAP_OPT_ to the uppercased array key.
@@ -94,11 +94,9 @@ class DirectoryService
      */
     protected function setLdapOptions()
     {
-        if (!empty($this->options['ldapOptions']) && is_array($this->options['ldapOptions'])) {
-            foreach ($this->options['ldapOptions'] as $ldapOption => $ldapOptionValue) {
-                $constantName = 'LDAP_OPT_' . strtoupper($ldapOption);
-                ldap_set_option($this->bindProvider->getLinkIdentifier(), constant($constantName), $ldapOptionValue);
-            }
+        foreach ($this->options['ldapOptions'] as $ldapOption => $value) {
+            $constantName = 'LDAP_OPT_' . strtoupper($ldapOption);
+            ldap_set_option($this->bindProvider->getLinkIdentifier(), constant($constantName), $value);
         }
     }
 

--- a/Classes/Service/DirectoryService.php
+++ b/Classes/Service/DirectoryService.php
@@ -73,11 +73,11 @@ class DirectoryService
             // Already connected
             return;
         }
-        
+
         $defaultClass = 'Neos\Ldap\Service\BindProvider\LdapBind';
         $bindProviderClass = isset($this->options['bindProvider']) ? $this->options['bindProvider'] : $defaultClass;
         if (!class_exists($bindProviderClass)) {
-            throw new Exception('Bind provider for the service "' . $this->name . '" could not be resolved.', 1327756744);
+            throw new Exception("Bind provider '$bindProviderClass' for the service '$this->name' could not be resolved.", 1327756744);
         }
 
         $connection = ldap_connect($this->options['host'], $this->options['port']);

--- a/Classes/Service/DirectoryService.php
+++ b/Classes/Service/DirectoryService.php
@@ -48,10 +48,6 @@ class DirectoryService
     {
         $this->name = $name;
         $this->options = $options;
-
-        if (!extension_loaded('ldap')) {
-            throw new Exception('PHP is not compiled with Ldap support', 1305406047);
-        }
     }
 
     /**

--- a/Classes/Service/DirectoryService.php
+++ b/Classes/Service/DirectoryService.php
@@ -128,7 +128,8 @@ class DirectoryService
             throw new Exception('Error during Ldap user search: ' . ldap_errno($this->bindProvider->getLinkIdentifier()), 1443798372);
         }
 
-        return current(ldap_get_entries($this->bindProvider->getLinkIdentifier(), $searchResult)) ?: null;
+        $entries = ldap_get_entries($this->bindProvider->getLinkIdentifier(), $searchResult);
+        return count($entries) ? $entries[0] : null;
     }
 
     /**
@@ -162,7 +163,10 @@ class DirectoryService
 
         return array_map(
             function (array $memberOf) { return $memberOf['dn']; },
-            ldap_get_entries($this->bindProvider->getLinkIdentifier(), $searchResult)
+            array_filter(
+                ldap_get_entries($this->bindProvider->getLinkIdentifier(), $searchResult),
+                function ($element) { return is_array($element); }
+            )
         );
     }
 

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -1,11 +1,18 @@
 Neos:
   Ldap:
     roles:
+      # default roles to give each user
       default: []
+#        - 'Neos.Neos:RestrictedEditor'
+      # map group memberships to roles
       groupMapping: []
+#        'Neos.Neos:Administrator':
+#          - 'CN=Administrators,OU=Groups,DC=domain,DC=tld'
+#        'Neos.Neos:Editor':
+#          - 'CN=Editors,OU=Groups,DC=domain,DC=tld'
+      # map certain users to roles
       userMapping: []
-    party: 
-      # this is an eel expression that should evaluate into an identifier that can be
-      # used in the membershipFilter option like (&(member=?)(objectClass=group))
-#      username: 'ldapUser.dn' # for ActiveDirectory provider
-    defaultContext: []
+#        'Neos.Neos:Administrator':
+#          - 'CN=Admin,OU=Users,DC=domain,DC=tld'
+#        'Neos.Neos:Editor':
+#          - 'CN=Mustermann,OU=Users,DC=domain,DC=tld'

--- a/Configuration/Settings.yaml.ad.example
+++ b/Configuration/Settings.yaml.ad.example
@@ -11,11 +11,6 @@ Neos:
               port: 389
               baseDn: dc=my-domain,dc=com
 
-              group:
-                membershipFilter: '(&(member=%s)(objectClass=group))'
-                dn: 'dn'
-                cn: 'cn'
-
               # All PHP Ldap options can be set here. Make the constant lowercase
               # and remove the ldap_opt_ prefix.
               # Example: LDAP_OPT_PROTOCOL_VERSION becomes protocol_version
@@ -23,9 +18,10 @@ Neos:
                 protocol_version: 3
                 referrals: 0
 
-              # ? will be replaced with the username provided
               filter:
-                account: '(samaccountname=?)'
+                # %s will be replaced with the username / dn provided
+                account: '(samaccountname=%s)'
+                memberOf: '(&(member=%s)(objectClass=group))'
 
                 # this will use the filter with domain, set it to yes to remove it for search
                 ignoreDomain: FALSE

--- a/Configuration/Settings.yaml.ad.example
+++ b/Configuration/Settings.yaml.ad.example
@@ -6,11 +6,13 @@ Neos:
           ActiveDirectoryProvider:
             provider: Neos\Ldap\Security\Authentication\Provider\LdapProvider
             providerOptions:
-              bindProvider: Neos\Ldap\Service\BindProvider\ActiveDirectoryBind
               host: localhost
               port: 389
-              
+
               baseDn: dc=my-domain,dc=com
+
+              bind:
+                provider: Neos\Ldap\Service\BindProvider\ActiveDirectoryBind
 
               # All PHP Ldap options can be set here. Make the constant lowercase
               # and remove the ldap_opt_ prefix.

--- a/Configuration/Settings.yaml.ad.example
+++ b/Configuration/Settings.yaml.ad.example
@@ -6,9 +6,10 @@ Neos:
           ActiveDirectoryProvider:
             provider: Neos\Ldap\Security\Authentication\Provider\LdapProvider
             providerOptions:
-              type: 'ActiveDirectory'
+              bindProvider: Neos\Ldap\Service\BindProvider\ActiveDirectoryBind
               host: localhost
               port: 389
+              
               baseDn: dc=my-domain,dc=com
 
               # All PHP Ldap options can be set here. Make the constant lowercase

--- a/Configuration/Settings.yaml.ldap.example
+++ b/Configuration/Settings.yaml.ldap.example
@@ -11,11 +11,6 @@ Neos:
               port: 389
               baseDn: dc=my-domain,dc=com
 
-              group:
-                membershipFilter: '(&(objectClass=posixGroup)(memberUid=%s))'
-                dn: 'dn'
-                cn: 'cn'
-
               bind:
                 anonymous: TRUE
                 dn:
@@ -29,9 +24,10 @@ Neos:
               ldapOptions:
                 protocol_version: 3
 
-              # ? will be replaced with the username provided
               filter:
-                account: '(uid=?)'
+                # %s will be replaced with the username / dn provided
+                account: '(samaccountname=%s)'
+                memberOf: '(&(objectClass=posixGroup)(memberUid=%s))'
 
                 # this will use the filter with domain, set it to yes to remove it for search
                 ignoreDomain: TRUE

--- a/Configuration/Settings.yaml.ldap.example
+++ b/Configuration/Settings.yaml.ldap.example
@@ -6,9 +6,10 @@ Neos:
           LdapProvider:
             provider: Neos\Ldap\Security\Authentication\Provider\LdapProvider
             providerOptions:
-              type: 'Ldap'
+              bindProvider: Neos\Ldap\Service\BindProvider\LdapBind
               host: localhost
               port: 389
+              
               baseDn: dc=my-domain,dc=com
 
               bind:

--- a/Configuration/Settings.yaml.ldap.example
+++ b/Configuration/Settings.yaml.ldap.example
@@ -26,7 +26,7 @@ Neos:
 
               filter:
                 # %s will be replaced with the username / dn provided
-                account: '(samaccountname=%s)'
+                account: '(uid=%s)'
                 memberOf: '(&(objectClass=posixGroup)(memberUid=%s))'
 
                 # this will use the filter with domain, set it to yes to remove it for search

--- a/Configuration/Settings.yaml.ldap.example
+++ b/Configuration/Settings.yaml.ldap.example
@@ -6,13 +6,13 @@ Neos:
           LdapProvider:
             provider: Neos\Ldap\Security\Authentication\Provider\LdapProvider
             providerOptions:
-              bindProvider: Neos\Ldap\Service\BindProvider\LdapBind
               host: localhost
               port: 389
-              
+
               baseDn: dc=my-domain,dc=com
 
               bind:
+                provider: Neos\Ldap\Service\BindProvider\LdapBind
                 anonymous: TRUE
                 dn:
                 password:


### PR DESCRIPTION
- streamlined authentication control flow (less nesting)
- drop `createParty()` and `updateParty()` in favour of signals `accountCreated` and `accountAuthenticated`
- drop eel party evaluation (it only resolves the user and group dns anyway)
- added example content to `Settings.yaml`