### PR TITLE
BUGFIX: Reset roles before collecting new ones

### DIFF
--- a/Classes/Security/Authentication/Provider/LdapProvider.php
+++ b/Classes/Security/Authentication/Provider/LdapProvider.php
@@ -134,11 +134,20 @@ class LdapProvider extends PersistedUsernamePasswordProvider
      */
     protected function setRoles(Account $account, array $ldapSearchResult)
     {
+        $this->resetRoles($account);
         $this->setDefaultRoles($account);
         $this->setRolesMappedToUserDn($account, $ldapSearchResult);
         $this->setRolesBasedOnGroupMembership($account, $ldapSearchResult);
 
         $this->accountRepository->update($account);
+    }
+
+    /**
+     * @param Account $account
+     */
+    protected function resetRoles(Account $account)
+    {
+        $account->setRoles([]);
     }
 
     /**


### PR DESCRIPTION
…to allow access downgrades.

Before, mapped roles were only ever added to the existing set but never removed, so regardless of your current state in the LDAP system you never could lose a status that was once given.