### PR TITLE
Add Flow 6.x compatibility

### DIFF
--- a/Classes/Security/Authentication/Provider/LdapProvider.php
+++ b/Classes/Security/Authentication/Provider/LdapProvider.php
@@ -20,6 +20,7 @@ use Neos\Flow\Security\Authentication\TokenInterface;
 use Neos\Flow\Security\Exception\UnsupportedAuthenticationTokenException;
 use Neos\Flow\Security\Policy\PolicyService;
 use Neos\Ldap\Service\DirectoryService;
+use Psr\Log\LogLevel;
 
 /**
  * Ldap Authentication provider
@@ -102,7 +103,7 @@ class LdapProvider extends PersistedUsernamePasswordProvider
             $authenticationToken->setAccount($account);
             $this->emitAccountAuthenticated($account, $ldapUser);
         } catch (\Exception $exception) {
-            $this->logger->log(LOG_ALERT, 'Authentication failed: ' . $exception->getMessage());
+            $this->logger->log(LogLevel::ALERT, 'Authentication failed: ' . $exception->getMessage());
             $authenticationToken->setAuthenticationStatus(TokenInterface::WRONG_CREDENTIALS);
         }
     }

--- a/Classes/Security/Authentication/Provider/LdapProvider.php
+++ b/Classes/Security/Authentication/Provider/LdapProvider.php
@@ -103,7 +103,7 @@ class LdapProvider extends PersistedUsernamePasswordProvider
             $authenticationToken->setAccount($account);
             $this->emitAccountAuthenticated($account, $ldapUser);
         } catch (\Exception $exception) {
-            $this->logger->log(LogLevel::ALERT, 'Authentication failed: ' . $exception->getMessage());
+            $this->logger->alert('Authentication failed: ' . $exception->getMessage());
             $authenticationToken->setAuthenticationStatus(TokenInterface::WRONG_CREDENTIALS);
         }
     }

--- a/Classes/Security/Authentication/Provider/LdapProvider.php
+++ b/Classes/Security/Authentication/Provider/LdapProvider.php
@@ -102,7 +102,7 @@ class LdapProvider extends PersistedUsernamePasswordProvider
             $authenticationToken->setAccount($account);
             $this->emitAccountAuthenticated($account, $ldapUser);
         } catch (\Exception $exception) {
-            $this->logger->log('Authentication failed: ' . $exception->getMessage(), LOG_ALERT);
+            $this->logger->log(LOG_ALERT, 'Authentication failed: ' . $exception->getMessage());
             $authenticationToken->setAuthenticationStatus(TokenInterface::WRONG_CREDENTIALS);
         }
     }

--- a/Classes/Security/Authentication/Provider/LdapProvider.php
+++ b/Classes/Security/Authentication/Provider/LdapProvider.php
@@ -20,7 +20,6 @@ use Neos\Flow\Security\Authentication\TokenInterface;
 use Neos\Flow\Security\Exception\UnsupportedAuthenticationTokenException;
 use Neos\Flow\Security\Policy\PolicyService;
 use Neos\Ldap\Service\DirectoryService;
-use Psr\Log\LogLevel;
 
 /**
  * Ldap Authentication provider

--- a/Classes/Security/Authentication/Provider/LdapProvider.php
+++ b/Classes/Security/Authentication/Provider/LdapProvider.php
@@ -12,7 +12,7 @@ namespace Neos\Ldap\Security\Authentication\Provider;
  */
 
 use Neos\Flow\Annotations as Flow;
-use Neos\Flow\Log\SecurityLoggerInterface;
+use Neos\Flow\Log\PsrSecurityLoggerInterface;
 use Neos\Flow\Security\Account;
 use Neos\Flow\Security\Authentication\Provider\PersistedUsernamePasswordProvider;
 use Neos\Flow\Security\Authentication\Token\UsernamePassword;
@@ -48,7 +48,7 @@ class LdapProvider extends PersistedUsernamePasswordProvider
 
     /**
      * @Flow\Inject
-     * @var SecurityLoggerInterface
+     * @var PsrSecurityLoggerInterface
      */
     protected $logger;
 

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "MIT"
     ],
     "require": {
-        "neos/flow": "^4.0 || ^5.0",
+        "neos/flow": "^4.0 || ^5.0 || ^6.0",
         "ext-ldap": "*"
     },
     "replace": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "MIT"
     ],
     "require": {
-        "neos/flow": "^4.0 || ^5.0 || ^6.0",
+        "neos/flow": "^5.0 || ^6.0",
         "ext-ldap": "*"
     },
     "replace": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "MIT"
     ],
     "require": {
-        "neos/flow": "^5.0 || ^6.0",
+        "neos/flow": "^6.0",
         "ext-ldap": "*"
     },
     "replace": {


### PR DESCRIPTION
Changes the use of the `SecurityLoggerInterface` to `PsrSecurityLoggerInterface` and drops support for Flow 4.x accordingly.